### PR TITLE
Disable LFS again

### DIFF
--- a/llm/.gitattributes
+++ b/llm/.gitattributes
@@ -1,1 +1,0 @@
-local_models/** filter=lfs diff=lfs merge=lfs -text

--- a/llm/local_models/bert-finetuned-squad/README.md
+++ b/llm/local_models/bert-finetuned-squad/README.md
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb7db77284614b21799619e3606bc9e2b6b78a107e315af72ee681107309d16a
-size 361

--- a/llm/local_models/bert-finetuned-squad/README.md
+++ b/llm/local_models/bert-finetuned-squad/README.md
@@ -1,0 +1,14 @@
+# bert-finetuned-squad
+
+This is a fine-tuned model based on [bert-base-cased](https://huggingface.co/google-bert/bert-base-cased).
+It is fine-tuned on the SQuAD 1.1 dataset with the following hyperparameters:
+
+```python
+TrainingArguments(
+    evaluation_strategy="no",
+    learning_rate=2e-5,
+    num_train_epochs=3,
+    weight_decay=0.01,
+    fp16=True,
+)
+```

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/config.json
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/config.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d4c3a2914281f346ac0991d3e44d5e76f72e2fa5c9f3d1d193ac894aaad39e5
-size 671

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/model.safetensors
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/model.safetensors
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:beed4205cb2b7cd4d4c674be3c059cbb15902eab31d1e73b3ea6a7b9caf5953d
-size 430908208

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/optimizer.pt
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/optimizer.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2b5abfced5c8e7863a1680f9f4185ae8869a5bf9f5c7808d85620d12036496c
-size 861930618

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/rng_state.pth
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/rng_state.pth
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0fd54c1be530c1d309a9894ad20228a85da38cd3b9de11a8f150323cca7bede6
-size 13990

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/scheduler.pt
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/scheduler.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2299dd7b7b957e862a06b7e751e633c6af66fcd38d54097c07bce561c81b4e8b
-size 1064

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/special_tokens_map.json
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/special_tokens_map.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6d346be366a7d1d48332dbc9fdf3bf8960b5d879522b7799ddba59e76237ee3
-size 125

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/tokenizer.json
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/tokenizer.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:343989712a36cd8b253efeaf8baf6a08b9d2583f78e395e83832e8ee9f8d8ee1
-size 668923

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/tokenizer_config.json
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/tokenizer_config.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:214f78f6c5d034a8b405632d301ee3710eb6f075b3f5faf8241a273a13908746
-size 1191

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/trainer_state.json
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/trainer_state.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8c52d98d917797a18cfd64251760fd50bb1aea3cb6377ec901eff2a07e2c6bcd
-size 12253

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/training_args.bin
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/training_args.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:109071ee0d185da3dc6ad4c0c38dcb2a786caa530a8b5c6e9bbc1c0f80b2e3cc
-size 5112

--- a/llm/local_models/bert-finetuned-squad/checkpoint-33276/vocab.txt
+++ b/llm/local_models/bert-finetuned-squad/checkpoint-33276/vocab.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eeaa9875b23b04b4c54ef759d03db9d1ba1554838f8fb26c5d96fa551df93d02
-size 213450

--- a/llm/local_models/roberta_base_large_G_tuned/README.md
+++ b/llm/local_models/roberta_base_large_G_tuned/README.md
@@ -1,0 +1,13 @@
+# roberta-base-large-G-tuned
+
+This is a fine-tuned model based on [roberta-large-squad2](https://huggingface.co/deepset/roberta-large-squad2).
+It is fine-tuned on the SQuAD 1.1 dataset with the following hyperparameters:
+
+```python
+TrainingArguments(
+    evaluation_strategy="epoch",
+    learning_rate=2e-5,
+    num_train_epochs=3,
+    weight_decay=0.01,
+)
+```

--- a/llm/local_models/roberta_base_large_G_tuned/README.md
+++ b/llm/local_models/roberta_base_large_G_tuned/README.md
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6700d988ddb4e241a9d4135e5051443da0c762ae9454c70745c8c60cefe47ef1
-size 361

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/config.json
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/config.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ebec07eb1e435fa67f4db4acc1bdd424b2a92322257d4ac52c8d58213a115c5
-size 809

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/merges.txt
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/merges.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5
-size 456318

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/model.safetensors
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/model.safetensors
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d7144a7df134c14d61b7c6236a0f5fd7b411e4e68fac001ed8d73b4be4e9819
-size 1417296784

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/special_tokens_map.json
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/special_tokens_map.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b72f59af007f804a5b6514f6ed8d59b4723349105471bcc3a881591fd586e2d5
-size 1009

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/tokenizer.json
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/tokenizer.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f929ddc659a14dc7f01e405981f5578e4d79042747a4eb4d231f3d7aeae475d
-size 2108906

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/tokenizer_config.json
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/tokenizer_config.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b31397b60b8d3ea14e6baa8aeb1579feb438926e628fe5efa0200351dd149bae
-size 1299

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/training_args.bin
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/training_args.bin
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11e7f78d3ad00b96683045866278ca125985e0b5239a592a78aa16533a82bebf
-size 5048

--- a/llm/local_models/roberta_base_large_G_tuned/checkpoint/vocab.json
+++ b/llm/local_models/roberta_base_large_G_tuned/checkpoint/vocab.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed19656ea1707df69134c4af35c8ceda2cc9860bf2c3495026153a133670ab5e
-size 798293


### PR DESCRIPTION
Since this caused clone issues due to the limited LFS bandwidth on Github, we will have to provide the local models via cloud storage link.