### PR TITLE
Add jupyter notebook dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ multiprocess==0.70.16
 nest-asyncio==1.6.0
 networkx==3.3
 nltk @ git+https://github.com/nltk/nltk@8c233dc585b91c7a0c58f96a9d99244a379740d5
+notebook==7.2.1
 numpy==1.26.4
 packaging==24.0
 pandas==2.2.2


### PR DESCRIPTION
This adds the dependency necessary for `jupyter notebook` to work: https://pypi.org/project/notebook/

Since it was already installed in the environment, we didn't notice this missing dependency so far.